### PR TITLE
Swiftlint Compliance and Improvements

### DIFF
--- a/Clean Swift/Interactor.xctemplate/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Interactor.xctemplate/___FILEBASENAME___Interactor.swift
@@ -23,58 +23,64 @@ class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic,
 
     // MARK: - Properties
 
-    var worker: ___VARIABLE_sceneName___Worker? = ___VARIABLE_sceneName___Worker()
+    typealias Models = ___VARIABLE_sceneName___Models
+
+    lazy var worker = ___VARIABLE_sceneName___Worker()
     var presenter: ___VARIABLE_sceneName___PresentationLogic?
+
     var exampleVariable: String?
 
     // MARK: - Use Case - Fetch From Local DataStore
 
     func fetchFromLocalDataStore(with request: ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Request) {
-        let response = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Response()
+        let response = Models.FetchFromLocalDataStore.Response()
         presenter?.presentFetchFromLocalDataStore(with: response)
     }
 
     // MARK: - Use Case - Fetch From Remote DataStore
 
     func fetchFromRemoteDataStore(with request: ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request) {
-        worker?.fetchFromRemoteDataStore(completion: {
-            [weak self] code in
-            let response = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Response(exampleVariable: code)
-            self?.presenter?.presentFetchFromRemoteDataStore(with: response)
-        })
+        // fetch something from backend and return the values here
+        // <#Network Worker Instance#>.fetchFromRemoteDataStore(completion: { [weak self] code in
+        //     let response = Models.FetchFromRemoteDataStore.Response(exampleVariable: code)
+        //     self?.presenter?.presentFetchFromRemoteDataStore(with: response)
+        // })
     }
 
     // MARK: - Use Case - Track Analytics
 
     func trackAnalytics(with request: ___VARIABLE_sceneName___Models.TrackAnalytics.Request) {
-        worker?.trackAnalytics(event: request.event)
+        // call analytics library/wrapper here to track analytics
+        // <#Analytics Worker Instance#>.trackAnalytics(event: request.event)
 
-        let response = ___VARIABLE_sceneName___Models.TrackAnalytics.Response()
+        let response = Models.TrackAnalytics.Response()
         presenter?.presentTrackAnalytics(with: response)
     }
 
     // MARK: - Use Case - ___VARIABLE_sceneName___
 
     func perform___VARIABLE_sceneName___(with request: ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request) {
-        worker?.validate(exampleVariable: request.exampleVariable)
+        let error = worker.validate(exampleVariable: request.exampleVariable)
 
-        if let error = worker?.error {
-            let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response(error: error)
+        if let error = error {
+            let response = Models.Perform___VARIABLE_sceneName___.Response(error: error)
             presenter?.presentPerform___VARIABLE_sceneName___(with: response)
             return
         }
 
-        worker?.perform___VARIABLE_sceneName___(completion: {
-            [weak self, request] isSuccessful, error in
+        // <#Network Worker Instance#>.perform___VARIABLE_sceneName___(completion: { [weak self, weak request] isSuccessful, error in
+        //     self?.completion(request?.exampleVariable, isSuccessful, error)
+        // })
+    }
 
-            if isSuccessful {
-                // do something on success
-                let goodExample = request.exampleVariable ?? ""
-                self?.exampleVariable = goodExample
-            }
+    private func completion(_ exampleVariable: String?, _ isSuccessful: Bool, _ error: Models.___VARIABLE_sceneName___Error?) {
+        if isSuccessful {
+            // do something on success
+            let goodExample = exampleVariable ?? ""
+            self.exampleVariable = goodExample
+        }
 
-            let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response(error: error)
-            self?.presenter?.presentPerform___VARIABLE_sceneName___(with: response)
-        })
+        let response = Models.Perform___VARIABLE_sceneName___.Response(error: error)
+        presenter?.presentPerform___VARIABLE_sceneName___(with: response)
     }
 }

--- a/Clean Swift/Models.xctemplate/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Models.xctemplate/___FILEBASENAME___Models.swift
@@ -55,22 +55,26 @@ enum ___VARIABLE_sceneName___Models {
         }
 
         struct Response {
-            var error: Error<___VARIABLE_sceneName___ErrorType>?
+            var error: ___VARIABLE_sceneName___Error?
         }
 
         struct ViewModel {
-            var error: Error<___VARIABLE_sceneName___ErrorType>?
+            var error: ___VARIABLE_sceneName___Error?
         }
     }
 
-    // MARK: - View Models
+    // MARK: - Types
 
-    enum AnalyticsEvents {
+    // replace with `AnalyticsEvents` with `AnalyticsConstants` if needed
+    typealias AnalyticsEvents = ExampleAnalyticsEvents
+    typealias ___VARIABLE_sceneName___Error = Error<___VARIABLE_sceneName___ErrorType>
+
+    enum ExampleAnalyticsEvents {
         case screenView
     }
 
     enum ___VARIABLE_sceneName___ErrorType {
-        case emptyExampleVariable, apiError
+        case emptyExampleVariable, networkError
     }
 
     struct Error<T> {

--- a/Clean Swift/Presenter.xctemplate/___FILEBASENAME___Presenter.swift
+++ b/Clean Swift/Presenter.xctemplate/___FILEBASENAME___Presenter.swift
@@ -19,38 +19,29 @@ class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLog
 
     // MARK: - Properties
 
+    typealias Models = ___VARIABLE_sceneName___Models
     weak var viewController: ___VARIABLE_sceneName___DisplayLogic?
 
     // MARK: - Use Case - Fetch From Local DataStore
 
     func presentFetchFromLocalDataStore(with response: ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Response) {
-        let translation = "Some localised text."
-        let viewModel = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
+        let translation = "Some localized text."
+        let viewModel = Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
         viewController?.displayFetchFromLocalDataStore(with: viewModel)
     }
 
     // MARK: - Use Case - Fetch From Remote DataStore
 
     func presentFetchFromRemoteDataStore(with response: ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Response) {
-        let code = response.exampleVariable
-        var exampleText: String
-
-        switch code {
-        case "0000":
-            exampleText = "Success!"
-
-        default:
-            exampleText = "Oops."
-        }
-
-        let viewModel = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: exampleText)
+        let formattedExampleVariable = response.exampleVariable ?? ""
+        let viewModel = Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: formattedExampleVariable)
         viewController?.displayFetchFromRemoteDataStore(with: viewModel)
     }
 
     // MARK: - Use Case - Track Analytics
 
     func presentTrackAnalytics(with response: ___VARIABLE_sceneName___Models.TrackAnalytics.Response) {
-        let viewModel = ___VARIABLE_sceneName___Models.TrackAnalytics.ViewModel()
+        let viewModel = Models.TrackAnalytics.ViewModel()
         viewController?.displayTrackAnalytics(with: viewModel)
     }
 
@@ -62,14 +53,14 @@ class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLog
         if let error = responseError {
             switch error.type {
             case .emptyExampleVariable:
-                responseError?.message = "Localised empty/nil error message."
+                responseError?.message = "Localized empty/nil error message."
 
-            case .apiError:
-                responseError?.message = "Localised api error message."
+            case .networkError:
+                responseError?.message = "Localized network error message."
             }
         }
 
-        let viewModel = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.ViewModel(error: responseError)
+        let viewModel = Models.Perform___VARIABLE_sceneName___.ViewModel(error: responseError)
         viewController?.displayPerform___VARIABLE_sceneName___(with: viewModel)
     }
 }

--- a/Clean Swift/Router.xctemplate/___FILEBASENAME___Router.swift
+++ b/Clean Swift/Router.xctemplate/___FILEBASENAME___Router.swift
@@ -20,7 +20,7 @@ class ___VARIABLE_sceneName___Router: NSObject, ___VARIABLE_sceneName___RoutingL
 
     // MARK: - Properties
 
-    var viewController: ___VARIABLE_sceneName___ViewController?
+    weak var viewController: ___VARIABLE_sceneName___ViewController?
     var dataStore: ___VARIABLE_sceneName___DataStore?
 
     // MARK: - Routing

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
@@ -24,58 +24,63 @@ class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic,
     // MARK: - Properties
 
     typealias Models = ___VARIABLE_sceneName___Models
-    var worker: ___VARIABLE_sceneName___Worker? = ___VARIABLE_sceneName___Worker()
+
+    lazy var worker = ___VARIABLE_sceneName___Worker()
     var presenter: ___VARIABLE_sceneName___PresentationLogic?
+
     var exampleVariable: String?
 
     // MARK: - Use Case - Fetch From Local DataStore
 
     func fetchFromLocalDataStore(with request: ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Request) {
-        let response = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Response()
+        let response = Models.FetchFromLocalDataStore.Response()
         presenter?.presentFetchFromLocalDataStore(with: response)
     }
 
     // MARK: - Use Case - Fetch From Remote DataStore
 
     func fetchFromRemoteDataStore(with request: ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request) {
-        worker?.fetchFromRemoteDataStore(completion: {
-            [weak self] code in
-            let response = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Response(exampleVariable: code)
-            self?.presenter?.presentFetchFromRemoteDataStore(with: response)
-        })
+        // fetch something from backend and return the values here
+        // <#Network Worker Instance#>.fetchFromRemoteDataStore(completion: { [weak self] code in
+        //     let response = Models.FetchFromRemoteDataStore.Response(exampleVariable: code)
+        //     self?.presenter?.presentFetchFromRemoteDataStore(with: response)
+        // })
     }
 
     // MARK: - Use Case - Track Analytics
 
     func trackAnalytics(with request: ___VARIABLE_sceneName___Models.TrackAnalytics.Request) {
-        worker?.trackAnalytics(event: request.event)
+        // call analytics library/wrapper here to track analytics
+        // <#Analytics Worker Instance#>.trackAnalytics(event: request.event)
 
-        let response = ___VARIABLE_sceneName___Models.TrackAnalytics.Response()
+        let response = Models.TrackAnalytics.Response()
         presenter?.presentTrackAnalytics(with: response)
     }
 
     // MARK: - Use Case - ___VARIABLE_sceneName___
 
     func perform___VARIABLE_sceneName___(with request: ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request) {
-        worker?.validate(exampleVariable: request.exampleVariable)
+        let error = worker.validate(exampleVariable: request.exampleVariable)
 
-        if let error = worker?.error {
-            let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response(error: error)
+        if let error = error {
+            let response = Models.Perform___VARIABLE_sceneName___.Response(error: error)
             presenter?.presentPerform___VARIABLE_sceneName___(with: response)
             return
         }
 
-        worker?.perform___VARIABLE_sceneName___(completion: {
-            [weak self, request] isSuccessful, error in
+        // <#Network Worker Instance#>.perform___VARIABLE_sceneName___(completion: { [weak self, weak request] isSuccessful, error in
+        //     self?.completion(request?.exampleVariable, isSuccessful, error)
+        // })
+    }
 
-            if isSuccessful {
-                // do something on success
-                let goodExample = request.exampleVariable ?? ""
-                self?.exampleVariable = goodExample
-            }
+    private func completion(_ exampleVariable: String?, _ isSuccessful: Bool, _ error: Models.___VARIABLE_sceneName___Error?) {
+        if isSuccessful {
+            // do something on success
+            let goodExample = exampleVariable ?? ""
+            self.exampleVariable = goodExample
+        }
 
-            let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response(error: error)
-            self?.presenter?.presentPerform___VARIABLE_sceneName___(with: response)
-        })
+        let response = Models.Perform___VARIABLE_sceneName___.Response(error: error)
+        presenter?.presentPerform___VARIABLE_sceneName___(with: response)
     }
 }

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Interactor.swift
@@ -23,6 +23,7 @@ class ___VARIABLE_sceneName___Interactor: ___VARIABLE_sceneName___BusinessLogic,
 
     // MARK: - Properties
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var worker: ___VARIABLE_sceneName___Worker? = ___VARIABLE_sceneName___Worker()
     var presenter: ___VARIABLE_sceneName___PresentationLogic?
     var exampleVariable: String?

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Models.swift
@@ -55,20 +55,26 @@ enum ___VARIABLE_sceneName___Models {
         }
 
         struct Response {
-            var error: Error<___VARIABLE_sceneName___ErrorType>?
+            var error: ___VARIABLE_sceneName___Error?
         }
 
         struct ViewModel {
-            var error: Error<___VARIABLE_sceneName___ErrorType>?
+            var error: ___VARIABLE_sceneName___Error?
         }
     }
 
     // MARK: - Types
 
-    typealias AnalyticsEvents = <#Path.To.Analytics.Constants#>
+    // replace with `AnalyticsEvents` with `AnalyticsConstants` if needed
+    typealias AnalyticsEvents = ExampleAnalyticsEvents
+    typealias ___VARIABLE_sceneName___Error = Error<___VARIABLE_sceneName___ErrorType>
+
+    enum ExampleAnalyticsEvents {
+        case screenView
+    }
 
     enum ___VARIABLE_sceneName___ErrorType {
-        case emptyExampleVariable, apiError
+        case emptyExampleVariable, networkError
     }
 
     struct Error<T> {

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Models.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Models.swift
@@ -63,11 +63,9 @@ enum ___VARIABLE_sceneName___Models {
         }
     }
 
-    // MARK: - View Models
+    // MARK: - Types
 
-    enum AnalyticsEvents {
-        case screenView
-    }
+    typealias AnalyticsEvents = <#Path.To.Analytics.Constants#>
 
     enum ___VARIABLE_sceneName___ErrorType {
         case emptyExampleVariable, apiError

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Presenter.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Presenter.swift
@@ -19,38 +19,29 @@ class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLog
 
     // MARK: - Properties
 
+    typealias Models = ___VARIABLE_sceneName___Models
     weak var viewController: ___VARIABLE_sceneName___DisplayLogic?
 
     // MARK: - Use Case - Fetch From Local DataStore
 
     func presentFetchFromLocalDataStore(with response: ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Response) {
-        let translation = "Some localised text."
-        let viewModel = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
+        let translation = "Some localized text."
+        let viewModel = Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
         viewController?.displayFetchFromLocalDataStore(with: viewModel)
     }
 
     // MARK: - Use Case - Fetch From Remote DataStore
 
     func presentFetchFromRemoteDataStore(with response: ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Response) {
-        let code = response.exampleVariable
-        var exampleText: String
-
-        switch code {
-        case "0000":
-            exampleText = "Success!"
-
-        default:
-            exampleText = "Oops."
-        }
-
-        let viewModel = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: exampleText)
+        let formattedExampleVariable = response.exampleVariable ?? ""
+        let viewModel = Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: formattedExampleVariable)
         viewController?.displayFetchFromRemoteDataStore(with: viewModel)
     }
 
     // MARK: - Use Case - Track Analytics
 
     func presentTrackAnalytics(with response: ___VARIABLE_sceneName___Models.TrackAnalytics.Response) {
-        let viewModel = ___VARIABLE_sceneName___Models.TrackAnalytics.ViewModel()
+        let viewModel = Models.TrackAnalytics.ViewModel()
         viewController?.displayTrackAnalytics(with: viewModel)
     }
 
@@ -62,14 +53,14 @@ class ___VARIABLE_sceneName___Presenter: ___VARIABLE_sceneName___PresentationLog
         if let error = responseError {
             switch error.type {
             case .emptyExampleVariable:
-                responseError?.message = "Localised empty/nil error message."
+                responseError?.message = "Localized empty/nil error message."
 
-            case .apiError:
-                responseError?.message = "Localised api error message."
+            case .networkError:
+                responseError?.message = "Localized network error message."
             }
         }
 
-        let viewModel = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.ViewModel(error: responseError)
+        let viewModel = Models.Perform___VARIABLE_sceneName___.ViewModel(error: responseError)
         viewController?.displayPerform___VARIABLE_sceneName___(with: viewModel)
     }
 }

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Router.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Router.swift
@@ -20,7 +20,7 @@ class ___VARIABLE_sceneName___Router: NSObject, ___VARIABLE_sceneName___RoutingL
 
     // MARK: - Properties
 
-    var viewController: ___VARIABLE_sceneName___ViewController?
+    weak var viewController: ___VARIABLE_sceneName___ViewController?
     var dataStore: ___VARIABLE_sceneName___DataStore?
 
     // MARK: - Routing

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
@@ -19,6 +19,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     // MARK: - Properties
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
     var interactor: ___VARIABLE_sceneName___BusinessLogic?
 
@@ -89,7 +90,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     @IBOutlet var exampleLocalLabel: UILabel! = UILabel()
     func setupFetchFromLocalDataStore() {
-        let request = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Request()
+        let request = Models.FetchFromLocalDataStore.Request()
         interactor?.fetchFromLocalDataStore(with: request)
     }
 
@@ -101,7 +102,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     @IBOutlet var exampleRemoteLabel: UILabel! = UILabel()
     func setupFetchFromRemoteDataStore() {
-        let request = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request()
+        let request = Models.FetchFromRemoteDataStore.Request()
         interactor?.fetchFromRemoteDataStore(with: request)
     }
 
@@ -116,7 +117,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
     }
 
     func trackAnalytics(event: ___VARIABLE_sceneName___Models.AnalyticsEvents) {
-        let request = ___VARIABLE_sceneName___Models.TrackAnalytics.Request(event: event)
+        let request = Models.TrackAnalytics.Request(event: event)
         interactor?.trackAnalytics(with: request)
     }
 
@@ -127,7 +128,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
     // MARK: - Use Case - ___VARIABLE_sceneName___
 
     func perform___VARIABLE_sceneName___(_ sender: Any) {
-        let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: exampleLocalLabel.text)
+        let request = Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: exampleLocalLabel.text)
         interactor?.perform___VARIABLE_sceneName___(with: request)
     }
 

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
@@ -112,7 +112,8 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     // MARK: - Use Case - Track Analytics
 
-    @objc func trackScreenViewAnalytics() {
+    @objc
+    func trackScreenViewAnalytics() {
         trackAnalytics(event: .screenView)
     }
 
@@ -140,9 +141,10 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
             case .emptyExampleVariable:
                 exampleLocalLabel.text = error.message
 
-            case .apiError:
+            case .networkError:
                 exampleLocalLabel.text = error.message
             }
+
             return
         }
 

--- a/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Worker.swift
+++ b/Clean Swift/Scene.xctemplate/UIViewController/___FILEBASENAME___Worker.swift
@@ -12,47 +12,21 @@ class ___VARIABLE_sceneName___Worker {
 
     // MARK: - Properties
 
-    typealias ErrorType = ___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType
-    var error: ___VARIABLE_sceneName___Models.Error<ErrorType>?
+    typealias Models = ___VARIABLE_sceneName___Models
 
     // MARK: - Methods
 
-    // MARK: Fetch From Remote DataStore
+    // MARK: Screen Specific Validation
 
-    func fetchFromRemoteDataStore(completion: (_ code: String) -> Void) {
-        // fetch something from backend,
-        // and return the values here
-        let code = "0000"
-        completion(code)
-    }
+    func validate(exampleVariable: String?) -> Models.___VARIABLE_sceneName___Error? {
+        var error: Models.___VARIABLE_sceneName___Error?
 
-    // MARK: Validation
-
-    func validate(exampleVariable: String?) {
         if exampleVariable?.isEmpty == false {
             error = nil
+        } else {
+            error = Models.___VARIABLE_sceneName___Error(type: .emptyExampleVariable)
         }
-        else {
-            error = ___VARIABLE_sceneName___Models.Error<ErrorType>(type: .emptyExampleVariable)
-        }
-    }
 
-    // MARK: Track Analytics
-
-    func trackAnalytics(event: ___VARIABLE_sceneName___Models.AnalyticsEvents) {
-        switch event {
-        case .screenView:
-            // call analytics library/wrapper here to track analytics
-            break
-        }
-    }
-
-    // MARK: Perform ___VARIABLE_sceneName___
-
-    func perform___VARIABLE_sceneName___(completion: @escaping (Bool, ___VARIABLE_sceneName___Models.Error<ErrorType>?) -> Void) {
-        let isSuccessful = true
-        let error: ___VARIABLE_sceneName___Models.Error<ErrorType>? = nil
-
-        completion(isSuccessful, error)
+        return error
     }
 }

--- a/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___InteractorSpec.swift
+++ b/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___InteractorSpec.swift
@@ -15,6 +15,7 @@ class ___VARIABLE_sceneName___InteractorSpec: QuickSpec {
 
         // MARK: - Subject Under Test (SUT)
 
+        typealias Models = ___VARIABLE_sceneName___Models
         var sut: ___VARIABLE_sceneName___Interactor!
 
         // MARK: - Test Doubles
@@ -42,7 +43,7 @@ class ___VARIABLE_sceneName___InteractorSpec: QuickSpec {
         describe("fetch from local data store") {
             it("should ask presenter to format", closure: {
                 // given
-                let request = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Request()
+                let request = Models.FetchFromLocalDataStore.Request()
 
                 // when
                 sut.fetchFromLocalDataStore(with: request)
@@ -55,36 +56,26 @@ class ___VARIABLE_sceneName___InteractorSpec: QuickSpec {
         describe("fetch from remote data store") {
             beforeEach {
                 // given
-                let request = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request()
+                let request = Models.FetchFromRemoteDataStore.Request()
 
                 // when
                 sut.fetchFromRemoteDataStore(with: request)
             }
 
-            it("should ask worker to fetch from remote datastore", closure: {
-                // then
-                expect(workerSpy.fetchFromRemoteDataStoreCalled).toEventually(beTrue())
-            })
-
             it("should ask presenter to format", closure: {
                 // then
-                expect(presentationLogicSpy.presentFetchFromRemoteDataStoreCalled).toEventually(beTrue())
+                // expect(presentationLogicSpy.presentFetchFromRemoteDataStoreCalled).toEventually(beTrue())
             })
         }
 
         describe("track analytics") {
             beforeEach {
                 // given
-                let request = ___VARIABLE_sceneName___Models.TrackAnalytics.Request(event: .screenView)
+                let request = Models.TrackAnalytics.Request(event: .screenView)
 
                 // when
                 sut.trackAnalytics(with: request)
             }
-
-            it("should ask worker to track analytics", closure: {
-                // then
-                expect(workerSpy.trackAnalyticsCalled).to(beTrue())
-            })
 
             it("should ask presenter to format", closure: {
                 // then
@@ -95,7 +86,7 @@ class ___VARIABLE_sceneName___InteractorSpec: QuickSpec {
         describe("perform ___VARIABLE_sceneName___") {
             it("should validate example variable", closure: {
                 // given
-                let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request()
+                let request = Models.Perform___VARIABLE_sceneName___.Request()
 
                 // when
                 sut.perform___VARIABLE_sceneName___(with: request)
@@ -104,35 +95,9 @@ class ___VARIABLE_sceneName___InteractorSpec: QuickSpec {
                 expect(workerSpy.validateExampleVariableCalled).to(beTrue())
             })
 
-            context("when there are error(s)", closure: {
-                it("should not ask worker to perform ___VARIABLE_sceneName___", closure: {
-                    // given
-                    let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: nil)
-
-                    // when
-                    sut.perform___VARIABLE_sceneName___(with: request)
-
-                    // then
-                    expect(workerSpy.perform___VARIABLE_sceneName___Called).to(beFalse())
-                })
-            })
-
-            context("when there are no errors", closure: {
-                it("should ask worker to perform ___VARIABLE_sceneName___", closure: {
-                    // given
-                    let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: "Example string.")
-
-                    // when
-                    sut.perform___VARIABLE_sceneName___(with: request)
-
-                    // then
-                    expect(workerSpy.perform___VARIABLE_sceneName___Called).to(beTrue())
-                })
-            })
-
             it("should ask presenter to format", closure: {
                 // given
-                let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request()
+                let request = Models.Perform___VARIABLE_sceneName___.Request()
 
                 // when
                 sut.perform___VARIABLE_sceneName___(with: request)
@@ -204,31 +169,10 @@ extension ___VARIABLE_sceneName___InteractorSpec {
 
         // MARK: Spied Methods
 
-        var fetchFromRemoteDataStoreCalled = false
-        override func fetchFromRemoteDataStore(completion: (_ code: String) -> Void) {
-            super.fetchFromRemoteDataStore(completion: {
-                [weak self] code in
-                self?.fetchFromRemoteDataStoreCalled = true
-                completion(code)
-            })
-        }
-
         var validateExampleVariableCalled = false
-        override func validate(exampleVariable: String?) {
-            super.validate(exampleVariable: exampleVariable)
+        override func validate(exampleVariable: String?) -> ___VARIABLE_sceneName___Worker.Models.___VARIABLE_sceneName___Error? {
             validateExampleVariableCalled = true
-        }
-
-        var trackAnalyticsCalled = false
-        override func trackAnalytics(event: ___VARIABLE_sceneName___Models.AnalyticsEvents) {
-            super.trackAnalytics(event: event)
-            trackAnalyticsCalled = true
-        }
-
-        var perform___VARIABLE_sceneName___Called = false
-        override func perform___VARIABLE_sceneName___(completion: @escaping (Bool, ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Worker.ErrorType>?) -> Void) {
-            super.perform___VARIABLE_sceneName___(completion: completion)
-            perform___VARIABLE_sceneName___Called = true
+            return super.validate(exampleVariable: exampleVariable)
         }
     }
 }

--- a/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___PresenterSpec.swift
+++ b/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___PresenterSpec.swift
@@ -15,6 +15,7 @@ class ___VARIABLE_sceneName___PresenterSpec: QuickSpec {
 
         // MARK: - Subject Under Test (SUT)
 
+        typealias Models = NewGroupModels
         var sut: ___VARIABLE_sceneName___Presenter!
 
         // MARK: - Test Doubles
@@ -39,7 +40,7 @@ class ___VARIABLE_sceneName___PresenterSpec: QuickSpec {
         describe("present fetch from local data store") {
             it("should ask view controller to display", closure: {
                 // given
-                let response = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Response()
+                let response = Models.FetchFromLocalDataStore.Response()
 
                 // when
                 sut.presentFetchFromLocalDataStore(with: response)
@@ -52,7 +53,7 @@ class ___VARIABLE_sceneName___PresenterSpec: QuickSpec {
         describe("present fetch from remote data store") {
             it("should ask view controller to display", closure: {
                 // given
-                let response = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Response()
+                let response = Models.FetchFromRemoteDataStore.Response()
 
                 // when
                 sut.presentFetchFromRemoteDataStore(with: response)
@@ -65,7 +66,7 @@ class ___VARIABLE_sceneName___PresenterSpec: QuickSpec {
         describe("present track analytics") {
             it("should ask view controller to display", closure: {
                 // given
-                let response = ___VARIABLE_sceneName___Models.TrackAnalytics.Response()
+                let response = Models.TrackAnalytics.Response()
 
                 // when
                 sut.presentTrackAnalytics(with: response)
@@ -79,8 +80,8 @@ class ___VARIABLE_sceneName___PresenterSpec: QuickSpec {
             context("when there are error(s)", closure: {
                 it("should return error message", closure: {
                     // given
-                    let error = ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>.init(type: .emptyExampleVariable)
-                    let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response(error: error)
+                    let error = Models.___VARIABLE_sceneName___Error(type: .emptyExampleVariable)
+                    let response = Models.Perform___VARIABLE_sceneName___.Response(error: error)
 
                     // when
                     sut.presentPerform___VARIABLE_sceneName___(with: response)
@@ -92,7 +93,7 @@ class ___VARIABLE_sceneName___PresenterSpec: QuickSpec {
 
             it("should ask view controller to display", closure: {
                 // given
-                let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response()
+                let response = Models.Perform___VARIABLE_sceneName___.Response()
 
                 // when
                 sut.presentPerform___VARIABLE_sceneName___(with: response)

--- a/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___ViewControllerSpec.swift
+++ b/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___ViewControllerSpec.swift
@@ -15,6 +15,7 @@ class ___VARIABLE_sceneName___ViewControllerSpec: QuickSpec {
 
         // MARK: - Subject Under Test (SUT)
 
+        typealias Models = ___VARIABLE_sceneName___Models
         var sut: ___VARIABLE_sceneName___ViewController!
         var window: UIWindow!
 
@@ -89,7 +90,7 @@ class ___VARIABLE_sceneName___ViewControllerSpec: QuickSpec {
                 // given
                 loadView()
                 let translation = "Example string."
-                let viewModel = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
+                let viewModel = Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
 
                 // when
                 sut.displayFetchFromLocalDataStore(with: viewModel)
@@ -104,7 +105,7 @@ class ___VARIABLE_sceneName___ViewControllerSpec: QuickSpec {
                 // given
                 loadView()
                 let exampleVariable = "Example string."
-                let viewModel = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: exampleVariable)
+                let viewModel = Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: exampleVariable)
 
                 // when
                 sut.displayFetchFromRemoteDataStore(with: viewModel)
@@ -118,7 +119,7 @@ class ___VARIABLE_sceneName___ViewControllerSpec: QuickSpec {
             it("should display track analytics", closure: {
                 // given
                 loadView()
-                let viewModel = ___VARIABLE_sceneName___Models.TrackAnalytics.ViewModel()
+                let viewModel = Models.TrackAnalytics.ViewModel()
 
                 // when
                 sut.displayTrackAnalytics(with: viewModel)
@@ -130,14 +131,14 @@ class ___VARIABLE_sceneName___ViewControllerSpec: QuickSpec {
 
         describe("display perform ___VARIABLE_sceneName___") {
             context("when there is an error", closure: {
-                var error: ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>!
+                var error: Models.___VARIABLE_sceneName___Error!
 
                 beforeEach {
                     // given
                     loadView()
-                    error = ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>.init(type: .emptyExampleVariable)
+                    error = Models.___VARIABLE_sceneName___Error(type: .emptyExampleVariable)
                     error.message = "Example error"
-                    let viewModel = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.ViewModel(error: error)
+                    let viewModel = Models.Perform___VARIABLE_sceneName___.ViewModel(error: error)
 
                     // when
                     sut.displayPerform___VARIABLE_sceneName___(with: viewModel)
@@ -158,7 +159,7 @@ class ___VARIABLE_sceneName___ViewControllerSpec: QuickSpec {
                 it("should route to next", closure: {
                     // given
                     loadView()
-                    let viewModel = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.ViewModel(error: nil)
+                    let viewModel = Models.Perform___VARIABLE_sceneName___.ViewModel(error: nil)
 
                     // when
                     sut.displayPerform___VARIABLE_sceneName___(with: viewModel)

--- a/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___WorkerSpec.swift
+++ b/Clean Swift/Unit Tests (Quick-Nimble).xctemplate/___FILEBASENAME___WorkerSpec.swift
@@ -15,6 +15,7 @@ class ___VARIABLE_sceneName___WorkerSpec: QuickSpec {
 
         // MARK: - Subject Under Test (SUT)
 
+        typealias Models = ___VARIABLE_sceneName___Models
         var sut: ___VARIABLE_sceneName___Worker!
 
         // MARK: - Test Doubles
@@ -31,23 +32,6 @@ class ___VARIABLE_sceneName___WorkerSpec: QuickSpec {
 
         // MARK: - Methods
 
-        describe("fetch from remote datastore") {
-            it("should return a string", closure: {
-                // given
-                var actualOutput = ""
-                let expectedOutput = "0000"
-
-                // when
-                sut.fetchFromRemoteDataStore(completion: {
-                    code in
-                    actualOutput = code
-                })
-
-                // then
-                expect(actualOutput).toEventually(equal(expectedOutput))
-            })
-        }
-
         describe("validate example variable") {
             context("example variable is nil", closure: {
                 it("should create empty example variable error", closure: {
@@ -55,11 +39,11 @@ class ___VARIABLE_sceneName___WorkerSpec: QuickSpec {
                     let exampleVariable: String? = nil
 
                     // when
-                    sut.validate(exampleVariable: exampleVariable)
+                    let error = sut.validate(exampleVariable: exampleVariable)
 
                     // then
-                    expect(sut.error).notTo(beNil())
-                    expect(sut.error?.type).to(equal(___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable))
+                    expect(error).notTo(beNil())
+                    expect(error?.type).to(equal(Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable))
                 })
             })
 
@@ -69,11 +53,11 @@ class ___VARIABLE_sceneName___WorkerSpec: QuickSpec {
                     let exampleVariable = ""
 
                     // when
-                    sut.validate(exampleVariable: exampleVariable)
+                    let error = sut.validate(exampleVariable: exampleVariable)
 
                     // then
-                    expect(sut.error).notTo(beNil())
-                    expect(sut.error?.type).to(equal(___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable))
+                    expect(error).notTo(beNil())
+                    expect(error?.type).to(equal(Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable))
                 })
             })
 
@@ -83,42 +67,11 @@ class ___VARIABLE_sceneName___WorkerSpec: QuickSpec {
                     let exampleVariable = "Example string."
 
                     // when
-                    sut.validate(exampleVariable: exampleVariable)
+                    let error = sut.validate(exampleVariable: exampleVariable)
 
                     // then
-                    expect(sut.error).to(beNil())
+                    expect(error).to(beNil())
                 })
-            })
-        }
-
-        describe("track analytics") {
-            context("when event is screen view", closure: {
-                it("should track analytics", closure: {
-                    // given
-                    let event: ___VARIABLE_sceneName___Models.AnalyticsEvents = .screenView
-
-                    // when
-                    sut.trackAnalytics(event: event)
-
-                    // then
-                    // assert something here based on use case
-                })
-            })
-        }
-
-        describe("perform ___VARIABLE_sceneName___") {
-            it("should always return true and without error response", closure: {
-                // given
-                var response: (isSuccessful: Bool, error: ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>?)!
-
-                // when
-                sut.perform___VARIABLE_sceneName___(completion: { (isSuccessful, error) in
-                    response = (isSuccessful, error)
-                })
-
-                // then
-                expect(response.isSuccessful).toEventually(beTrue())
-                expect(response.error).toEventually(beNil())
             })
         }
 

--- a/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___InteractorTests.swift
+++ b/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___InteractorTests.swift
@@ -13,6 +13,7 @@ class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
 
     // MARK: - Subject Under Test (SUT)
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var sut: ___VARIABLE_sceneName___Interactor!
 
     // MARK: - Test Lifecycle
@@ -72,31 +73,10 @@ class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
 
         // MARK: Spied Methods
 
-        var fetchFromRemoteDataStoreCalled = false
-        override func fetchFromRemoteDataStore(completion: (_ code: String) -> Void) {
-            super.fetchFromRemoteDataStore(completion: {
-                [weak self] code in
-                self?.fetchFromRemoteDataStoreCalled = true
-                completion(code)
-            })
-        }
-
         var validateExampleVariableCalled = false
-        override func validate(exampleVariable: String?) {
-            super.validate(exampleVariable: exampleVariable)
+        override func validate(exampleVariable: String?) -> Models.___VARIABLE_sceneName___Error? {
             validateExampleVariableCalled = true
-        }
-
-        var trackAnalyticsCalled = false
-        override func trackAnalytics(event: ___VARIABLE_sceneName___Models.AnalyticsEvents) {
-            super.trackAnalytics(event: event)
-            trackAnalyticsCalled = true
-        }
-
-        var perform___VARIABLE_sceneName___Called = false
-        override func perform___VARIABLE_sceneName___(completion: @escaping (Bool, ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Worker.ErrorType>?) -> Void) {
-            super.perform___VARIABLE_sceneName___(completion: completion)
-            perform___VARIABLE_sceneName___Called = true
+            return super.validate(exampleVariable: exampleVariable)
         }
     }
 
@@ -106,7 +86,7 @@ class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
         // given
         let spy = ___VARIABLE_sceneName___PresentationLogicSpy()
         sut.presenter = spy
-        let request = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Request()
+        let request = Models.FetchFromLocalDataStore.Request()
 
         // when
         sut.fetchFromLocalDataStore(with: request)
@@ -115,50 +95,11 @@ class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
         XCTAssertTrue(spy.presentFetchFromLocalDataStoreCalled, "fetchFromLocalDataStore(with:) should ask the presenter to format the result")
     }
 
-    func testFetchFromRemoteDataStoreShouldAskWorkerToFetchFromRemoteDataStore() {
-        // given
-        let spy = ___VARIABLE_sceneName___WorkerSpy()
-        sut.worker = spy
-        let request = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request()
-
-        // when
-        sut.fetchFromRemoteDataStore(with: request)
-
-        // then
-        XCTAssertTrue(spy.fetchFromRemoteDataStoreCalled, "fetchFromRemoteDataStore(with:) should ask the worker to fetch from remote data store")
-    }
-
-    func testFetchFromRemoteDataStoreShouldAskPresenterToFormat() {
-        // given
-        let spy = ___VARIABLE_sceneName___PresentationLogicSpy()
-        sut.presenter = spy
-        let request = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request()
-
-        // when
-        sut.fetchFromRemoteDataStore(with: request)
-
-        // then
-        XCTAssertTrue(spy.presentFetchFromRemoteDataStoreCalled, "fetchFromRemoteDataStore(with:) should ask the presenter to format the result")
-    }
-
-    func testTrackAnalyticsShouldAskWorkerToTrackAnalytics() {
-        // given
-        let spy = ___VARIABLE_sceneName___WorkerSpy()
-        sut.worker = spy
-        let request = ___VARIABLE_sceneName___Models.TrackAnalytics.Request(event: .screenView)
-
-        // when
-        sut.trackAnalytics(with: request)
-
-        // then
-        XCTAssertTrue(spy.trackAnalyticsCalled, "trackAnalytics(with:) should ask the worker to track analytics")
-    }
-
     func testTrackAnalyticsShouldAskPresenterToFormat() {
         // given
         let spy = ___VARIABLE_sceneName___PresentationLogicSpy()
         sut.presenter = spy
-        let request = ___VARIABLE_sceneName___Models.TrackAnalytics.Request(event: .screenView)
+        let request = Models.TrackAnalytics.Request(event: .screenView)
 
         // when
         sut.trackAnalytics(with: request)
@@ -171,7 +112,7 @@ class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
         // given
         let spy = ___VARIABLE_sceneName___WorkerSpy()
         sut.worker = spy
-        let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request()
+        let request = Models.Perform___VARIABLE_sceneName___.Request()
 
         // when
         sut.perform___VARIABLE_sceneName___(with: request)
@@ -180,37 +121,11 @@ class ___VARIABLE_sceneName___InteractorTests: XCTestCase {
         XCTAssertTrue(spy.validateExampleVariableCalled, "perform___VARIABLE_sceneName___(with:) should ask the worker to validate the example variable")
     }
 
-    func testPerform___VARIABLE_sceneName___ShouldNotAskWorkerToPerform___VARIABLE_sceneName___IfThereAreErrors() {
-        // given
-        let spy = ___VARIABLE_sceneName___WorkerSpy()
-        sut.worker = spy
-        let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: nil)
-
-        // when
-        sut.perform___VARIABLE_sceneName___(with: request)
-
-        // then
-        XCTAssertFalse(spy.perform___VARIABLE_sceneName___Called, "perform___VARIABLE_sceneName___(with:) should not ask the worker to perform ___VARIABLE_sceneName___")
-    }
-
-    func testPerform___VARIABLE_sceneName___ShouldAskWorkerToPerform___VARIABLE_sceneName___IfThereAreNoErrors() {
-        // given
-        let spy = ___VARIABLE_sceneName___WorkerSpy()
-        sut.worker = spy
-        let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: "Example string.")
-
-        // when
-        sut.perform___VARIABLE_sceneName___(with: request)
-
-        // then
-        XCTAssertTrue(spy.perform___VARIABLE_sceneName___Called, "perform___VARIABLE_sceneName___(with:) should ask the worker to perform ___VARIABLE_sceneName___")
-    }
-
     func testPerform___VARIABLE_sceneName___ShouldAskPresenterToFormat() {
         // given
         let spy = ___VARIABLE_sceneName___PresentationLogicSpy()
         sut.presenter = spy
-        let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request()
+        let request = Models.Perform___VARIABLE_sceneName___.Request()
 
         // when
         let expect = expectation(description: "Wait for perform___VARIABLE_sceneName___(with:) to return")

--- a/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___PresenterTests.swift
+++ b/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___PresenterTests.swift
@@ -13,6 +13,7 @@ class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
 
     // MARK: - Subject Under Test (SUT)
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var sut: ___VARIABLE_sceneName___Presenter!
 
     // MARK: - Test Lifecycle
@@ -74,7 +75,7 @@ class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
         // given
         let spy = ___VARIABLE_sceneName___DisplayLogicSpy()
         sut.viewController = spy
-        let response = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Response()
+        let response = Models.FetchFromLocalDataStore.Response()
 
         // when
         sut.presentFetchFromLocalDataStore(with: response)
@@ -87,7 +88,7 @@ class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
         // given
         let spy = ___VARIABLE_sceneName___DisplayLogicSpy()
         sut.viewController = spy
-        let response = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Response()
+        let response = Models.FetchFromRemoteDataStore.Response()
 
         // when
         sut.presentFetchFromRemoteDataStore(with: response)
@@ -100,7 +101,7 @@ class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
         // given
         let spy = ___VARIABLE_sceneName___DisplayLogicSpy()
         sut.viewController = spy
-        let response = ___VARIABLE_sceneName___Models.TrackAnalytics.Response()
+        let response = Models.TrackAnalytics.Response()
 
         // when
         sut.presentTrackAnalytics(with: response)
@@ -113,7 +114,7 @@ class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
         // given
         let spy = ___VARIABLE_sceneName___DisplayLogicSpy()
         sut.viewController = spy
-        let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response()
+        let response = Models.Perform___VARIABLE_sceneName___.Response()
 
         // when
         sut.presentPerform___VARIABLE_sceneName___(with: response)
@@ -124,10 +125,10 @@ class ___VARIABLE_sceneName___PresenterTests: XCTestCase {
 
     func testPresentPerform___VARIABLE_sceneName___ShouldReturnErrorMessageIfThereIsAnError() {
         // given
-        let error = ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>.init(type: .emptyExampleVariable)
+        let error = Models.___VARIABLE_sceneName___Error(type: .emptyExampleVariable)
         let spy = ___VARIABLE_sceneName___DisplayLogicSpy()
         sut.viewController = spy
-        let response = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Response(error: error)
+        let response = Models.Perform___VARIABLE_sceneName___.Response(error: error)
 
         // when
         sut.presentPerform___VARIABLE_sceneName___(with: response)

--- a/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___ViewControllerTests.swift
+++ b/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___ViewControllerTests.swift
@@ -13,6 +13,7 @@ class ___VARIABLE_sceneName___ViewControllerTests: XCTestCase {
 
     // MARK: - Subject Under Test (SUT)
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var sut: ___VARIABLE_sceneName___ViewController!
     var window: UIWindow!
 
@@ -98,7 +99,7 @@ class ___VARIABLE_sceneName___ViewControllerTests: XCTestCase {
         // given
         loadView()
         let translation = "Example string."
-        let viewModel = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
+        let viewModel = Models.FetchFromLocalDataStore.ViewModel(exampleTranslation: translation)
 
         // when
         sut.displayFetchFromLocalDataStore(with: viewModel)
@@ -123,7 +124,7 @@ class ___VARIABLE_sceneName___ViewControllerTests: XCTestCase {
         // given
         loadView()
         let exampleVariable = "Example string."
-        let viewModel = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: exampleVariable)
+        let viewModel = Models.FetchFromRemoteDataStore.ViewModel(exampleVariable: exampleVariable)
 
         // when
         sut.displayFetchFromRemoteDataStore(with: viewModel)
@@ -148,7 +149,7 @@ class ___VARIABLE_sceneName___ViewControllerTests: XCTestCase {
     func testShouldDisplayTrackAnalyticsWhenDisplayTrackAnalytics() {
         // given
         loadView()
-        let viewModel = ___VARIABLE_sceneName___Models.TrackAnalytics.ViewModel()
+        let viewModel = Models.TrackAnalytics.ViewModel()
 
         // when
         sut.displayTrackAnalytics(with: viewModel)
@@ -160,9 +161,9 @@ class ___VARIABLE_sceneName___ViewControllerTests: XCTestCase {
     func testUnsuccessful___VARIABLE_sceneName___ShouldShowErrorAsLabel() {
         // given
         loadView()
-        var error = ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>.init(type: .emptyExampleVariable)
+        var error = Models.___VARIABLE_sceneName___Error(type: .emptyExampleVariable)
         error.message = "Example error"
-        let viewModel = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.ViewModel(error: error)
+        let viewModel = Models.Perform___VARIABLE_sceneName___.ViewModel(error: error)
 
         // when
         sut.displayPerform___VARIABLE_sceneName___(with: viewModel)

--- a/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___WorkerTests.swift
+++ b/Clean Swift/Unit Tests (XCTest).xctemplate/___FILEBASENAME___WorkerTests.swift
@@ -13,6 +13,7 @@ class ___VARIABLE_sceneName___WorkerTests: XCTestCase {
 
     // MARK: - Subject Under Test (SUT)
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var sut: ___VARIABLE_sceneName___Worker!
 
     // MARK: - Test Lifecycle
@@ -37,34 +38,16 @@ class ___VARIABLE_sceneName___WorkerTests: XCTestCase {
 
     // MARK: - Tests
 
-    func testFetchFromRemoteDataStoreShouldReturnAString() {
-        // given
-        var actualOutput = ""
-        let expectedOutput = "0000"
-
-        // when
-        let expect = expectation(description: "Wait for fetchFromRemoteDataStore(completion:) to return")
-        sut.fetchFromRemoteDataStore {
-            code in
-            actualOutput = code
-            expect.fulfill()
-        }
-        waitForExpectations(timeout: 1)
-
-        // then
-        XCTAssertEqual(actualOutput, expectedOutput, "fetchFromRemoteDataStore(completion:) should return a string")
-    }
-
     func testValidateExampleVariableShouldCreateEmptyExampleVariableErrorIfExampleVariableIsNil() {
         // given
         let exampleVariable: String? = nil
 
         // when
-        sut.validate(exampleVariable: exampleVariable)
+        let error = sut.validate(exampleVariable: exampleVariable)
 
         // then
-        XCTAssertNotNil(sut.error, "validate(exampleVariable:) should create an error if example variable is nil")
-        XCTAssertEqual(sut.error?.type, ___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable, "validate(exampleVariable:) should create an emptyExampleVariable error if example variable is nil")
+        XCTAssertNotNil(error, "validate(exampleVariable:) should create an error if example variable is nil")
+        XCTAssertEqual(error?.type, Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable, "validate(exampleVariable:) should create an emptyExampleVariable error if example variable is nil")
     }
 
     func testValidateExampleVariableShouldCreateEmptyExampleVariableErrorIfExampleVariableIsEmpty() {
@@ -72,11 +55,11 @@ class ___VARIABLE_sceneName___WorkerTests: XCTestCase {
         let exampleVariable = ""
 
         // when
-        sut.validate(exampleVariable: exampleVariable)
+        let error = sut.validate(exampleVariable: exampleVariable)
 
         // then
-        XCTAssertNotNil(sut.error, "validate(exampleVariable:) should create an error if example variable is empty")
-        XCTAssertEqual(sut.error?.type, ___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable, "validate(exampleVariable:) should create an emptyExampleVariable error if example variable is empty")
+        XCTAssertNotNil(error, "validate(exampleVariable:) should create an error if example variable is empty")
+        XCTAssertEqual(error?.type, Models.___VARIABLE_sceneName___ErrorType.emptyExampleVariable, "validate(exampleVariable:) should create an emptyExampleVariable error if example variable is empty")
     }
 
     func testValidateExampleVariableShouldNotCreateErrorIfExampleVariableIsNotNilOrEmpty() {
@@ -84,37 +67,9 @@ class ___VARIABLE_sceneName___WorkerTests: XCTestCase {
         let exampleVariable = "Example string."
 
         // when
-        sut.validate(exampleVariable: exampleVariable)
+        let error = sut.validate(exampleVariable: exampleVariable)
 
         // then
-        XCTAssertNil(sut.error, "validate(exampleVariable:) should not create an error if example variable is not nil or empty")
-    }
-
-    func testTrackAnalyticsShouldTrackAnalyticsIfEventIsScreenView() {
-        // given
-        let event: ___VARIABLE_sceneName___Models.AnalyticsEvents = .screenView
-
-        // when
-        sut.trackAnalytics(event: event)
-
-        // then
-        // assert something here based on use case
-    }
-
-    func testPerform___VARIABLE_sceneName___ShouldAlwaysReturnTrueAndWithoutErrorsResponse() {
-        // given
-        var response: (isSuccessful: Bool, error: ___VARIABLE_sceneName___Models.Error<___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType>?)!
-
-        // when
-        let expect = expectation(description: "Wait for perform___VARIABLE_sceneName___(completion:) to return")
-        sut.perform___VARIABLE_sceneName___ { (isSuccessful, error) in
-            response = (isSuccessful, error)
-            expect.fulfill()
-        }
-        waitForExpectations(timeout: 1)
-
-        // then
-        XCTAssertTrue(response.isSuccessful, "perform___VARIABLE_sceneName___(completion:) should always return true")
-        XCTAssertNil(response.error, "perform___VARIABLE_sceneName___(completion:) should not return errors")
+        XCTAssertNil(error, "validate(exampleVariable:) should not create an error if example variable is not nil or empty")
     }
 }

--- a/Clean Swift/View Controller.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
+++ b/Clean Swift/View Controller.xctemplate/UIViewController/___FILEBASENAME___ViewController.swift
@@ -19,6 +19,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     // MARK: - Properties
 
+    typealias Models = ___VARIABLE_sceneName___Models
     var router: (NSObjectProtocol & ___VARIABLE_sceneName___RoutingLogic & ___VARIABLE_sceneName___DataPassing)?
     var interactor: ___VARIABLE_sceneName___BusinessLogic?
 
@@ -89,7 +90,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     @IBOutlet var exampleLocalLabel: UILabel! = UILabel()
     func setupFetchFromLocalDataStore() {
-        let request = ___VARIABLE_sceneName___Models.FetchFromLocalDataStore.Request()
+        let request = Models.FetchFromLocalDataStore.Request()
         interactor?.fetchFromLocalDataStore(with: request)
     }
 
@@ -101,7 +102,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     @IBOutlet var exampleRemoteLabel: UILabel! = UILabel()
     func setupFetchFromRemoteDataStore() {
-        let request = ___VARIABLE_sceneName___Models.FetchFromRemoteDataStore.Request()
+        let request = Models.FetchFromRemoteDataStore.Request()
         interactor?.fetchFromRemoteDataStore(with: request)
     }
 
@@ -111,12 +112,13 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
 
     // MARK: - Use Case - Track Analytics
 
-    @objc func trackScreenViewAnalytics() {
+    @objc
+    func trackScreenViewAnalytics() {
         trackAnalytics(event: .screenView)
     }
 
     func trackAnalytics(event: ___VARIABLE_sceneName___Models.AnalyticsEvents) {
-        let request = ___VARIABLE_sceneName___Models.TrackAnalytics.Request(event: event)
+        let request = Models.TrackAnalytics.Request(event: event)
         interactor?.trackAnalytics(with: request)
     }
 
@@ -127,7 +129,7 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
     // MARK: - Use Case - ___VARIABLE_sceneName___
 
     func perform___VARIABLE_sceneName___(_ sender: Any) {
-        let request = ___VARIABLE_sceneName___Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: exampleLocalLabel.text)
+        let request = Models.Perform___VARIABLE_sceneName___.Request(exampleVariable: exampleLocalLabel.text)
         interactor?.perform___VARIABLE_sceneName___(with: request)
     }
 
@@ -139,9 +141,10 @@ class ___VARIABLE_sceneName___ViewController: UIViewController, ___VARIABLE_scen
             case .emptyExampleVariable:
                 exampleLocalLabel.text = error.message
 
-            case .apiError:
+            case .networkError:
                 exampleLocalLabel.text = error.message
             }
+
             return
         }
 

--- a/Clean Swift/Worker.xctemplate/___FILEBASENAME___Worker.swift
+++ b/Clean Swift/Worker.xctemplate/___FILEBASENAME___Worker.swift
@@ -12,47 +12,21 @@ class ___VARIABLE_sceneName___Worker {
 
     // MARK: - Properties
 
-    typealias ErrorType = ___VARIABLE_sceneName___Models.___VARIABLE_sceneName___ErrorType
-    var error: ___VARIABLE_sceneName___Models.Error<ErrorType>?
+    typealias Models = ___VARIABLE_sceneName___Models
 
     // MARK: - Methods
 
-    // MARK: Fetch From Remote DataStore
+    // MARK: Screen Specific Validation
 
-    func fetchFromRemoteDataStore(completion: (_ code: String) -> Void) {
-        // fetch something from backend,
-        // and return the values here
-        let code = "0000"
-        completion(code)
-    }
+    func validate(exampleVariable: String?) -> Models.___VARIABLE_sceneName___Error? {
+        var error: Models.___VARIABLE_sceneName___Error?
 
-    // MARK: Validation
-
-    func validate(exampleVariable: String?) {
         if exampleVariable?.isEmpty == false {
             error = nil
+        } else {
+            error = Models.___VARIABLE_sceneName___Error(type: .emptyExampleVariable)
         }
-        else {
-            error = ___VARIABLE_sceneName___Models.Error<ErrorType>(type: .emptyExampleVariable)
-        }
-    }
 
-    // MARK: Track Analytics
-
-    func trackAnalytics(event: ___VARIABLE_sceneName___Models.AnalyticsEvents) {
-        switch event {
-        case .screenView:
-            // call analytics library/wrapper here to track analytics
-            break
-        }
-    }
-
-    // MARK: Perform ___VARIABLE_sceneName___
-
-    func perform___VARIABLE_sceneName___(completion: @escaping (Bool, ___VARIABLE_sceneName___Models.Error<ErrorType>?) -> Void) {
-        let isSuccessful = true
-        let error: ___VARIABLE_sceneName___Models.Error<ErrorType>? = nil
-
-        completion(isSuccessful, error)
+        return error
     }
 }


### PR DESCRIPTION
# What's inside this PR?

- All
  - Added `typealias Models` to shorten call to each screen's models
- Business/Presentation/Display Protocols
  - Leave it to call the screen's model in full, to not unnecessary call a `typealias` from within Interactor, Presenter, ViewController respectively
- Models
  - Modified `AnalyticsEvents` to `typealias` to hint to refer to an centralised analytics constants enum
  - Declared `typealias Error = Error<ErrorType>` to simplify referencing to errors
  - Changed the comment header from `View Models` to `Types` to make more sense
  - Change `apiError` to `networkError` case to broaden the error scope
- Interactor
  - Simplified `fetchFromRemoteDataStore`, `trackAnalytics` and `perform___VARIABLE_sceneName___` use cases to be able to call shared workers directly, instead of having to wrap it through the screen's worker
  - Changed referencing screen worker as `lazy` as there's no specific reason to make it optional
- Router
  - Declared view controller as `weak` to prevent memory leaks
- Unit Tests
  - Updated both XCTest and Quick-Nimble templates to reflect the above changes

# How to manually test?

1. Install template using `$ make install_templates` command
1. On any Xcode project (that has the Quick & Nimble library installed)
    1. Create a new set of screen using the 'scene' template
    1. Create a new set of unit tests using both the XCTest & Quick-Nimble templates
1. Run unit test (CMD+U)
1. There should be no errors and all tests should pass